### PR TITLE
Add default value for multi value input

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.keycloak</groupId>
     <artifactId>keycloak-ipaddress-authenticator</artifactId>
-    <version>${keycloak.version}_1</version>
+    <version>${keycloak.version}_2</version>
     <name>Keycloak IP-Address Authenticator</name>
 
     <properties>

--- a/src/main/java/org/keycloak/authentication/authenticators/conditional/ConditionalClientIpAddressAuthenticatorFactory.java
+++ b/src/main/java/org/keycloak/authentication/authenticators/conditional/ConditionalClientIpAddressAuthenticatorFactory.java
@@ -73,6 +73,7 @@ public class ConditionalClientIpAddressAuthenticatorFactory implements Condition
         final ProviderConfigProperty ipRanges = new ProviderConfigProperty();
         ipRanges.setType(MULTIVALUED_STRING_TYPE);
         ipRanges.setName(CONF_IP_RANGES);
+        ipRanges.setDefaultValue("a:b:c:d::/64");
         ipRanges.setLabel("IP ranges / subnets");
         ipRanges.setHelpText("A list of IP ranges. Supports IPv6 and IPv4, supports CIDR and netmask notation. Examples: a:b:c:d::/64, a.b.c.d/255.255.0.0");
 


### PR DESCRIPTION
It seems to be necessary to provide a default value for `MULTIVALUED_STRING_TYPE` parameters, otherwise no input is shown and no input can be added.

Fixes #2 