### PR TITLE
Refactor handling of forwarded header

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,13 @@
             <version>${keycloak.version}</version>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.11.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.keycloak</groupId>
     <artifactId>keycloak-ipaddress-authenticator</artifactId>
-    <version>${keycloak.version}_0</version>
+    <version>${keycloak.version}_1</version>
     <name>Keycloak IP-Address Authenticator</name>
 
     <properties>

--- a/src/main/java/org/keycloak/authentication/authenticators/conditional/ConditionalClientIpAddressAuthenticator.java
+++ b/src/main/java/org/keycloak/authentication/authenticators/conditional/ConditionalClientIpAddressAuthenticator.java
@@ -29,6 +29,12 @@ public class ConditionalClientIpAddressAuthenticator implements ConditionalAuthe
 
         final ConditionalClientIpAddressAuthenticatorConfig config =
                 new ConditionalClientIpAddressAuthenticatorConfig(context.getAuthenticatorConfig());
+        return matchCondition(context, config);
+    }
+
+    // package-private for testing
+    boolean matchCondition(AuthenticationFlowContext context, ConditionalClientIpAddressAuthenticatorConfig config) {
+
         final Optional<IPAddress> clientIpAddress = getClientIpAddress(context, config);
 
         if (clientIpAddress.isPresent()) {

--- a/src/main/java/org/keycloak/authentication/authenticators/conditional/ConditionalClientIpAddressAuthenticator.java
+++ b/src/main/java/org/keycloak/authentication/authenticators/conditional/ConditionalClientIpAddressAuthenticator.java
@@ -3,6 +3,7 @@ package org.keycloak.authentication.authenticators.conditional;
 import inet.ipaddr.AddressStringException;
 import inet.ipaddr.IPAddress;
 import inet.ipaddr.IPAddressString;
+import inet.ipaddr.format.IPAddressRange;
 import org.jboss.logging.Logger;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.models.KeycloakSession;
@@ -11,30 +12,37 @@ import org.keycloak.models.UserModel;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
 import static java.text.MessageFormat.format;
-import static org.keycloak.authentication.authenticators.conditional.ConditionalClientIpAddressAuthenticatorFactory.CONF_EXCLUDE;
-import static org.keycloak.authentication.authenticators.conditional.ConditionalClientIpAddressAuthenticatorFactory.CONF_IP_RANGES;
-import static org.keycloak.models.Constants.CFG_DELIMITER_PATTERN;
+import static java.util.stream.Collectors.toList;
 
 public class ConditionalClientIpAddressAuthenticator implements ConditionalAuthenticator {
 
     public static final ConditionalClientIpAddressAuthenticator SINGLETON = new ConditionalClientIpAddressAuthenticator();
 
     private static final Logger LOG = Logger.getLogger(ConditionalClientIpAddressAuthenticator.class);
-    private static final String X_FORWARDED_FOR_HEADER_NAME = "X-Forwarded-For";
 
     @Override
     public boolean matchCondition(AuthenticationFlowContext context) {
 
-        final Map<String, String> config = context.getAuthenticatorConfig().getConfig();
-        final boolean exclude = Boolean.parseBoolean(config.get(CONF_EXCLUDE));
-        final Stream<IPAddress> ipRanges = getConfiguredIpRanges(config);
+        final ConditionalClientIpAddressAuthenticatorConfig config =
+                new ConditionalClientIpAddressAuthenticatorConfig(context.getAuthenticatorConfig());
+        final Optional<IPAddress> clientIpAddress = getClientIpAddress(context, config);
 
-        final IPAddress clientIpAddress = getClientIpAddress(context);
+        if (clientIpAddress.isPresent()) {
+            return doMatchCondition(clientIpAddress.get(), config);
+        } else {
+            return false;
+        }
+    }
+
+    private boolean doMatchCondition(IPAddress clientIpAddress, ConditionalClientIpAddressAuthenticatorConfig config) {
+
+        final boolean exclude = config.isExclude();
+        final Stream<IPAddressRange> ipRanges = config.getIpRanges().stream();
+
         if (exclude) {
             return ipRanges.noneMatch(ipRange -> ipRange.contains(clientIpAddress));
         } else {
@@ -42,55 +50,50 @@ public class ConditionalClientIpAddressAuthenticator implements ConditionalAuthe
         }
     }
 
-    private Stream<IPAddress> getConfiguredIpRanges(Map<String, String> config) {
+    private Optional<IPAddress> getClientIpAddress(AuthenticationFlowContext context, ConditionalClientIpAddressAuthenticatorConfig config) {
 
-        final String ipRangesString = config.get(CONF_IP_RANGES);
-        if (ipRangesString == null) {
-            throw new IllegalStateException("No IP ranges configured");
+        if (config.isUseForwardedHeader()) {
+            return getClientIpAddressFromForwardedHeader(context, config);
+        } else {
+            final String ipAddressStringFromConnection = context.getConnection().getRemoteAddr();
+            return parseIpAddress(ipAddressStringFromConnection);
         }
-
-        final String[] ipRanges = CFG_DELIMITER_PATTERN.split(ipRangesString);
-        if (ipRanges.length == 0) {
-            throw new IllegalStateException("No IP ranges configured");
-        }
-
-        return Arrays.stream(ipRanges)
-                .map(String::trim)
-                .filter(s -> !s.isEmpty())
-                .map(this::parseIpAddress)
-                .filter(Optional::isPresent)
-                .map(Optional::get);
     }
 
-    private IPAddress getClientIpAddress(AuthenticationFlowContext context) {
+    private Optional<IPAddress> getClientIpAddressFromForwardedHeader(AuthenticationFlowContext context, ConditionalClientIpAddressAuthenticatorConfig config) {
 
-        final List<String> xForwardedForHeaders = context.getHttpRequest()
+        final List<String> forwardedHeaders = context.getHttpRequest()
                 .getHttpHeaders()
-                .getRequestHeader(X_FORWARDED_FOR_HEADER_NAME);
-
-        final Optional<IPAddress> ipAddressFromForwardedHeader = xForwardedForHeaders
-                .stream()
-                .map(this::parseIpAddress)
-                .filter(Optional::isPresent)
-                .map(Optional::get)
-                .findFirst();
-        if (ipAddressFromForwardedHeader.isPresent()) {
-            return ipAddressFromForwardedHeader.get();
+                .getRequestHeader(config.getForwardedHeaderName().trim());
+        if (forwardedHeaders == null) {
+            return Optional.empty();
         }
 
-        final String ipAddressStringFromClientConnection = context.getConnection().getRemoteAddr();
-        final Optional<IPAddress> ipAddressFromConnection = parseIpAddress(ipAddressStringFromClientConnection);
-        if (ipAddressFromConnection.isPresent()) {
-            return ipAddressFromConnection.get();
+        final List<String> ipAddressesFromHeader = forwardedHeaders.stream()
+                .map(h -> h.split(","))
+                .flatMap(Arrays::stream)
+                .collect(toList());
+
+        if (ipAddressesFromHeader.isEmpty()) {
+            return Optional.empty();
         }
 
-        throw new IllegalStateException(format("No valid ip address found in {0} header ({1}) or in client connection ({2})",
-                X_FORWARDED_FOR_HEADER_NAME, xForwardedForHeaders, ipAddressStringFromClientConnection));
+        final int trustedProxiesCount = config.getTrustedProxiesCount();
+        final int numberOfIpAddressesInHeader = ipAddressesFromHeader.size();
+        if (numberOfIpAddressesInHeader < trustedProxiesCount) {
+            LOG.warn(format("Forwarded header contains less addresses than number of trusted proxies. Not possible to securely determine client ip address. Headers: {0}",
+                    forwardedHeaders));
+            return Optional.empty();
+        }
+
+        final int index = numberOfIpAddressesInHeader - trustedProxiesCount;
+        final String firstTrustedIpAddress = ipAddressesFromHeader.get(index);
+        return parseIpAddress(firstTrustedIpAddress);
     }
 
     private Optional<IPAddress> parseIpAddress(String text) {
 
-        IPAddressString ipAddressString = new IPAddressString(text);
+        IPAddressString ipAddressString = new IPAddressString(text.trim());
 
         if (!ipAddressString.isValid()) {
             LOG.warn("Ignoring invalid IP address " + ipAddressString);

--- a/src/main/java/org/keycloak/authentication/authenticators/conditional/ConditionalClientIpAddressAuthenticatorConfig.java
+++ b/src/main/java/org/keycloak/authentication/authenticators/conditional/ConditionalClientIpAddressAuthenticatorConfig.java
@@ -1,0 +1,104 @@
+package org.keycloak.authentication.authenticators.conditional;
+
+import inet.ipaddr.AddressStringException;
+import inet.ipaddr.IPAddress;
+import inet.ipaddr.IPAddressString;
+import inet.ipaddr.format.IPAddressRange;
+import org.jboss.logging.Logger;
+import org.keycloak.models.AuthenticatorConfigModel;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.keycloak.authentication.authenticators.conditional.ConditionalClientIpAddressAuthenticatorFactory.CONF_EXCLUDE;
+import static org.keycloak.authentication.authenticators.conditional.ConditionalClientIpAddressAuthenticatorFactory.CONF_FORWARDED_HEADER_NAME;
+import static org.keycloak.authentication.authenticators.conditional.ConditionalClientIpAddressAuthenticatorFactory.CONF_FORWARDED_HEADER_NAME_DEFAULT;
+import static org.keycloak.authentication.authenticators.conditional.ConditionalClientIpAddressAuthenticatorFactory.CONF_IP_RANGES;
+import static org.keycloak.authentication.authenticators.conditional.ConditionalClientIpAddressAuthenticatorFactory.CONF_TRUSTED_PROXIES_COUNT;
+import static org.keycloak.authentication.authenticators.conditional.ConditionalClientIpAddressAuthenticatorFactory.CONF_USE_FORWARDED_HEADER;
+import static org.keycloak.models.Constants.CFG_DELIMITER_PATTERN;
+
+class ConditionalClientIpAddressAuthenticatorConfig {
+
+    private static final Logger LOG = Logger.getLogger(ConditionalClientIpAddressAuthenticatorConfig.class);
+
+    final Set<IPAddressRange> ipRanges;
+    final boolean exclude;
+    final boolean useForwardedHeader;
+    final String forwardedHeaderName;
+    final int trustedProxiesCount;
+
+    public ConditionalClientIpAddressAuthenticatorConfig(AuthenticatorConfigModel configModel) {
+        this(configModel.getConfig());
+    }
+
+    public ConditionalClientIpAddressAuthenticatorConfig(Map<String, String> configMap) {
+        this.ipRanges = getConfiguredIpRanges(configMap);
+        this.exclude = Boolean.parseBoolean(configMap.get(CONF_EXCLUDE));
+        this.useForwardedHeader = Boolean.parseBoolean(configMap.get(CONF_USE_FORWARDED_HEADER));
+        this.forwardedHeaderName = configMap.getOrDefault(CONF_FORWARDED_HEADER_NAME, CONF_FORWARDED_HEADER_NAME_DEFAULT);
+        this.trustedProxiesCount = Integer.parseInt(configMap.get(CONF_TRUSTED_PROXIES_COUNT));
+    }
+
+    private Set<IPAddressRange> getConfiguredIpRanges(Map<String, String> config) {
+
+        final String ipRangesString = config.get(CONF_IP_RANGES);
+        if (ipRangesString == null) {
+            throw new IllegalStateException("No IP ranges configured");
+        }
+
+        final String[] ipRanges = CFG_DELIMITER_PATTERN.split(ipRangesString);
+        if (ipRanges.length == 0) {
+            throw new IllegalStateException("No IP ranges configured");
+        }
+
+        return Arrays.stream(ipRanges)
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .map(this::parseIpAddress)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toSet());
+    }
+
+    private Optional<IPAddress> parseIpAddress(String text) {
+
+        final IPAddressString ipAddressString = new IPAddressString(text);
+
+        if (!ipAddressString.isValid()) {
+            LOG.warn("Ignoring invalid IP address from config " + ipAddressString);
+            return Optional.empty();
+        }
+
+        try {
+            final IPAddress parsedIpAddress = ipAddressString.toAddress();
+            return Optional.of(parsedIpAddress);
+        } catch (AddressStringException e) {
+            LOG.warn("Ignoring invalid IP address from config " + ipAddressString, e);
+            return Optional.empty();
+        }
+    }
+
+    public Set<IPAddressRange> getIpRanges() {
+        return ipRanges;
+    }
+
+    public boolean isExclude() {
+        return exclude;
+    }
+
+    public boolean isUseForwardedHeader() {
+        return useForwardedHeader;
+    }
+
+    public String getForwardedHeaderName() {
+        return forwardedHeaderName;
+    }
+
+    public int getTrustedProxiesCount() {
+        return trustedProxiesCount;
+    }
+}

--- a/src/main/java/org/keycloak/authentication/authenticators/conditional/ConditionalClientIpAddressAuthenticatorConfig.java
+++ b/src/main/java/org/keycloak/authentication/authenticators/conditional/ConditionalClientIpAddressAuthenticatorConfig.java
@@ -25,17 +25,20 @@ class ConditionalClientIpAddressAuthenticatorConfig {
 
     private static final Logger LOG = Logger.getLogger(ConditionalClientIpAddressAuthenticatorConfig.class);
 
-    final Set<IPAddressRange> ipRanges;
-    final boolean exclude;
-    final boolean useForwardedHeader;
-    final String forwardedHeaderName;
-    final int trustedProxiesCount;
+    private Set<IPAddressRange> ipRanges;
+    private boolean exclude;
+    private boolean useForwardedHeader;
+    private String forwardedHeaderName;
+    private int trustedProxiesCount;
 
-    public ConditionalClientIpAddressAuthenticatorConfig(AuthenticatorConfigModel configModel) {
+    ConditionalClientIpAddressAuthenticatorConfig() {
+    }
+
+    ConditionalClientIpAddressAuthenticatorConfig(AuthenticatorConfigModel configModel) {
         this(configModel.getConfig());
     }
 
-    public ConditionalClientIpAddressAuthenticatorConfig(Map<String, String> configMap) {
+    ConditionalClientIpAddressAuthenticatorConfig(Map<String, String> configMap) {
         this.ipRanges = getConfiguredIpRanges(configMap);
         this.exclude = Boolean.parseBoolean(configMap.get(CONF_EXCLUDE));
         this.useForwardedHeader = Boolean.parseBoolean(configMap.get(CONF_USE_FORWARDED_HEADER));
@@ -86,19 +89,47 @@ class ConditionalClientIpAddressAuthenticatorConfig {
         return ipRanges;
     }
 
+    public void setIpRanges(Set<IPAddressRange> ipRanges) {
+        this.ipRanges = ipRanges;
+    }
+
+    public void setIpRanges(String... ipRanges) {
+        this.ipRanges = Arrays.stream(ipRanges)
+                .map(this::parseIpAddress)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toSet());
+    }
+
     public boolean isExclude() {
         return exclude;
+    }
+
+    public void setExclude(boolean exclude) {
+        this.exclude = exclude;
     }
 
     public boolean isUseForwardedHeader() {
         return useForwardedHeader;
     }
 
+    public void setUseForwardedHeader(boolean useForwardedHeader) {
+        this.useForwardedHeader = useForwardedHeader;
+    }
+
     public String getForwardedHeaderName() {
         return forwardedHeaderName;
     }
 
+    public void setForwardedHeaderName(String forwardedHeaderName) {
+        this.forwardedHeaderName = forwardedHeaderName;
+    }
+
     public int getTrustedProxiesCount() {
         return trustedProxiesCount;
+    }
+
+    public void setTrustedProxiesCount(int trustedProxiesCount) {
+        this.trustedProxiesCount = trustedProxiesCount;
     }
 }

--- a/src/main/java/org/keycloak/authentication/authenticators/conditional/ConditionalClientIpAddressAuthenticatorFactory.java
+++ b/src/main/java/org/keycloak/authentication/authenticators/conditional/ConditionalClientIpAddressAuthenticatorFactory.java
@@ -107,7 +107,7 @@ public class ConditionalClientIpAddressAuthenticatorFactory implements Condition
         trustedProxiesCount.setName(CONF_TRUSTED_PROXIES_COUNT);
         trustedProxiesCount.setLabel("Number of trusted proxies");
         trustedProxiesCount.setDefaultValue("1");
-        trustedProxiesCount.setHelpText("Number of trusted proxies. Only the last n ip addresses from the forwarded header will be used");
+        trustedProxiesCount.setHelpText("Number of trusted proxies in your network. Only the last n ip addresses from the forwarded header will be used.");
 
         return Arrays.asList(ipRanges, exclude, useForwardedHeader, forwardedHeaderName, trustedProxiesCount);
     }

--- a/src/main/java/org/keycloak/authentication/authenticators/conditional/ConditionalClientIpAddressAuthenticatorFactory.java
+++ b/src/main/java/org/keycloak/authentication/authenticators/conditional/ConditionalClientIpAddressAuthenticatorFactory.java
@@ -8,20 +8,24 @@ import org.keycloak.provider.ProviderConfigProperty;
 import java.util.Arrays;
 import java.util.List;
 
+import static java.text.MessageFormat.format;
 import static org.keycloak.provider.ProviderConfigProperty.BOOLEAN_TYPE;
 import static org.keycloak.provider.ProviderConfigProperty.MULTIVALUED_STRING_TYPE;
+import static org.keycloak.provider.ProviderConfigProperty.STRING_TYPE;
 
 public class ConditionalClientIpAddressAuthenticatorFactory implements ConditionalAuthenticatorFactory {
 
     public static final String PROVIDER_ID = "conditional-client-ip-address";
 
-    public static final String CONF_IP_RANGES = "ip-ranges";
-    public static final String CONF_EXCLUDE = "exclude";
+    static final String CONF_IP_RANGES = "ip-ranges";
+    static final String CONF_EXCLUDE = "exclude";
+    static final String CONF_USE_FORWARDED_HEADER = "use-forwarded-header";
+    static final String CONF_FORWARDED_HEADER_NAME = "forwarded-header-name";
+    static final String CONF_FORWARDED_HEADER_NAME_DEFAULT = "X-Forwarded-For";
+    static final String CONF_TRUSTED_PROXIES_COUNT = "trusted-proxies-count";
 
-    private static final AuthenticationExecutionModel.Requirement[] REQUIREMENT_CHOICES = new AuthenticationExecutionModel.Requirement[]{
-            AuthenticationExecutionModel.Requirement.REQUIRED,
-            AuthenticationExecutionModel.Requirement.DISABLED
-    };
+
+    private static final AuthenticationExecutionModel.Requirement[] REQUIREMENT_CHOICES = new AuthenticationExecutionModel.Requirement[]{AuthenticationExecutionModel.Requirement.REQUIRED, AuthenticationExecutionModel.Requirement.DISABLED};
 
     @Override
     public void init(Config.Scope config) {
@@ -83,7 +87,29 @@ public class ConditionalClientIpAddressAuthenticatorFactory implements Condition
         exclude.setLabel("Exclude specified ranges");
         exclude.setHelpText("Match if client IP address is NOT in specified ranges");
 
-        return Arrays.asList(ipRanges, exclude);
+        final ProviderConfigProperty useForwardedHeader = new ProviderConfigProperty();
+        useForwardedHeader.setType(BOOLEAN_TYPE);
+        useForwardedHeader.setName(CONF_USE_FORWARDED_HEADER);
+        useForwardedHeader.setLabel("Use a 'forwarded' header");
+        useForwardedHeader.setHelpText(format("Use IP addresses from a header added by reverse proxies (e.g. {0}). Be aware of security concerns when using this header and set 'Number of trusted proxies' accordingly (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For#security_and_privacy_concerns)",
+                CONF_FORWARDED_HEADER_NAME_DEFAULT));
+
+        final ProviderConfigProperty forwardedHeaderName = new ProviderConfigProperty();
+        forwardedHeaderName.setType(STRING_TYPE);
+        forwardedHeaderName.setName(CONF_FORWARDED_HEADER_NAME);
+        forwardedHeaderName.setLabel("Forwarded header name");
+        forwardedHeaderName.setDefaultValue(CONF_FORWARDED_HEADER_NAME_DEFAULT);
+        forwardedHeaderName.setRequired(false);
+        forwardedHeaderName.setHelpText(format("Optional: Name of the forwarded header (Default: {0})", CONF_FORWARDED_HEADER_NAME_DEFAULT));
+
+        final ProviderConfigProperty trustedProxiesCount = new ProviderConfigProperty();
+        trustedProxiesCount.setType(STRING_TYPE);
+        trustedProxiesCount.setName(CONF_TRUSTED_PROXIES_COUNT);
+        trustedProxiesCount.setLabel("Number of trusted proxies");
+        trustedProxiesCount.setDefaultValue("1");
+        trustedProxiesCount.setHelpText("Number of trusted proxies. Only the last n ip addresses from the forwarded header will be used");
+
+        return Arrays.asList(ipRanges, exclude, useForwardedHeader, forwardedHeaderName, trustedProxiesCount);
     }
 
     @Override

--- a/src/test/java/org/keycloak/authentication/authenticators/conditional/ConditionalClientIpAddressAuthenticatorTest.java
+++ b/src/test/java/org/keycloak/authentication/authenticators/conditional/ConditionalClientIpAddressAuthenticatorTest.java
@@ -1,0 +1,137 @@
+package org.keycloak.authentication.authenticators.conditional;
+
+import org.junit.jupiter.api.Test;
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.authenticators.conditional.util.TestAuthenticationFlowContext;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ConditionalClientIpAddressAuthenticatorTest {
+
+    final ConditionalClientIpAddressAuthenticator conditionalClientIpAddressAuthenticator = ConditionalClientIpAddressAuthenticator.SINGLETON;
+
+    @Test
+    void testAccessGrantedWithoutForwardedHeader() {
+
+        final ConditionalClientIpAddressAuthenticatorConfig config = new ConditionalClientIpAddressAuthenticatorConfig();
+        config.setIpRanges("1.2.3.0/24", "4.5.0.0/16");
+        config.setExclude(false);
+
+        config.setUseForwardedHeader(false);
+        config.setForwardedHeaderName("X-Forwarded-For");
+        config.setTrustedProxiesCount(1);
+
+        testAccessGranted(config, "1.2.3.4", "X-Forwarded-For", "7.8.9.0");
+    }
+
+    @Test
+    void testAccessDeniedWithoutForwardedHeader() {
+
+        final ConditionalClientIpAddressAuthenticatorConfig config = new ConditionalClientIpAddressAuthenticatorConfig();
+        config.setIpRanges("1.2.3.0/24", "4.5.0.0/16");
+        config.setExclude(false);
+
+        config.setUseForwardedHeader(false);
+        config.setForwardedHeaderName("X-Forwarded-For");
+        config.setTrustedProxiesCount(1);
+
+        testAccessDenied(config, "7.8.9.0", "X-Forwarded-For", "1.2.3.4");
+    }
+
+    @Test
+    void testAccessGrantedWithForwardedHeader() {
+
+        final ConditionalClientIpAddressAuthenticatorConfig config = new ConditionalClientIpAddressAuthenticatorConfig();
+        config.setIpRanges("1.2.3.0/24", "4.5.0.0/16");
+        config.setExclude(false);
+
+        config.setUseForwardedHeader(true);
+        config.setForwardedHeaderName("X-Forwarded-For");
+        config.setTrustedProxiesCount(1);
+
+        testAccessGranted(config, "7.8.9.0", "X-Forwarded-For", "1.2.3.4");
+    }
+
+    @Test
+    void testAccessDeniedWithForwardedHeader() {
+
+        final ConditionalClientIpAddressAuthenticatorConfig config = new ConditionalClientIpAddressAuthenticatorConfig();
+        config.setIpRanges("1.2.3.0/24", "4.5.0.0/16");
+        config.setExclude(false);
+
+        config.setUseForwardedHeader(true);
+        config.setForwardedHeaderName("X-Forwarded-For");
+        config.setTrustedProxiesCount(1);
+
+        testAccessDenied(config, "1.2.3.4", "X-Forwarded-For", "7.8.9.0");
+    }
+
+    @Test
+    void testUntrustedIpsInForwardedHeaderIgnored() {
+
+        final ConditionalClientIpAddressAuthenticatorConfig config = new ConditionalClientIpAddressAuthenticatorConfig();
+        config.setIpRanges("1.2.3.0/24", "4.5.0.0/16");
+        config.setExclude(false);
+
+        config.setUseForwardedHeader(true);
+        config.setForwardedHeaderName("X-Forwarded-For");
+        config.setTrustedProxiesCount(1);
+
+        testAccessDenied(config, "1.2.3.4", "X-Forwarded-For", "1.2.3.4, 7.8.9.0");
+    }
+
+    @Test
+    void testUntrustedIpsInForwardedHeaderIgnoredMultipleHeaders() {
+
+        final ConditionalClientIpAddressAuthenticatorConfig config = new ConditionalClientIpAddressAuthenticatorConfig();
+        config.setIpRanges("1.2.3.0/24", "4.5.0.0/16");
+        config.setExclude(false);
+
+        config.setUseForwardedHeader(true);
+        config.setForwardedHeaderName("X-Forwarded-For");
+        config.setTrustedProxiesCount(2);
+
+        testAccessGranted(config, "1.2.3.4", "X-Forwarded-For", "5.6.7.0", "1.2.3.4, 7.8.9.0");
+    }
+
+    @Test
+    void testAccessDeniedCustomHeaderMissing() {
+
+        final ConditionalClientIpAddressAuthenticatorConfig config = new ConditionalClientIpAddressAuthenticatorConfig();
+        config.setIpRanges("1.2.3.0/24", "4.5.0.0/16");
+        config.setExclude(false);
+
+        config.setUseForwardedHeader(true);
+        config.setForwardedHeaderName("X-Forwarded-Custom");
+        config.setTrustedProxiesCount(1);
+
+        testAccessDenied(config, "4.5.6.7", "X-Forwarded-For", "1.2.3.4");
+    }
+
+    private void testAccessGranted(ConditionalClientIpAddressAuthenticatorConfig config, String clientIp, String forwardedHeaderName, String... forwardedHeaderValues) {
+
+        final boolean accessGranted = test(config, clientIp, forwardedHeaderName, forwardedHeaderValues);
+        assertTrue(accessGranted);
+    }
+
+    private void testAccessDenied(ConditionalClientIpAddressAuthenticatorConfig config, String clientIp, String forwardedHeaderName, String... forwardedHeaderValues) {
+
+        final boolean accessGranted = test(config, clientIp, forwardedHeaderName, forwardedHeaderValues);
+        assertFalse(accessGranted);
+    }
+
+    private boolean test(ConditionalClientIpAddressAuthenticatorConfig config, String clientIp, String forwardedHeaderName, String... forwardedHeaderValues) {
+        final Map<String, List<String>> headers = new HashMap<>();
+        headers.put(forwardedHeaderName, asList(forwardedHeaderValues));
+
+        final AuthenticationFlowContext context = new TestAuthenticationFlowContext(clientIp, headers);
+        return conditionalClientIpAddressAuthenticator.matchCondition(context, config);
+    }
+
+}

--- a/src/test/java/org/keycloak/authentication/authenticators/conditional/util/TestAuthenticationFlowContext.java
+++ b/src/test/java/org/keycloak/authentication/authenticators/conditional/util/TestAuthenticationFlowContext.java
@@ -1,0 +1,278 @@
+package org.keycloak.authentication.authenticators.conditional.util;
+
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.AuthenticationFlowError;
+import org.keycloak.authentication.AuthenticationSelectionOption;
+import org.keycloak.authentication.FlowStatus;
+import org.keycloak.common.ClientConnection;
+import org.keycloak.events.EventBuilder;
+import org.keycloak.forms.login.LoginFormsProvider;
+import org.keycloak.http.HttpRequest;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.AuthenticationFlowModel;
+import org.keycloak.models.AuthenticatorConfigModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.UserSessionModel;
+import org.keycloak.models.utils.FormMessage;
+import org.keycloak.services.managers.BruteForceProtector;
+import org.keycloak.sessions.AuthenticationSessionModel;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
+public class TestAuthenticationFlowContext implements AuthenticationFlowContext {
+
+        private final ClientConnection clientConnection;
+        private final HttpRequest httpRequest;
+
+        public TestAuthenticationFlowContext(String clientIp, Map<String, List<String>> headers) {
+
+            this.clientConnection = new TestClientConnection(clientIp);
+            this.httpRequest = new TestHttpRequest(headers);
+        }
+
+        @Override
+        public ClientConnection getConnection() {
+            return clientConnection;
+        }
+
+        @Override
+        public HttpRequest getHttpRequest() {
+           return httpRequest;
+        }
+
+        @Override
+        public AuthenticatorConfigModel getAuthenticatorConfig() {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public UserModel getUser() {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public void setUser(UserModel user) {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public List<AuthenticationSelectionOption> getAuthenticationSelections() {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public void setAuthenticationSelections(List<AuthenticationSelectionOption> credentialAuthExecMap) {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public void clearUser() {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public void attachUserSession(UserSessionModel userSession) {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public AuthenticationSessionModel getAuthenticationSession() {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public String getFlowPath() {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public LoginFormsProvider form() {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public URI getActionUrl(String code) {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public URI getActionTokenUrl(String tokenString) {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public URI getRefreshExecutionUrl() {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public URI getRefreshUrl(boolean authSessionIdParam) {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public void cancelLogin() {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public void resetFlow() {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public void resetFlow(Runnable afterResetListener) {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public void fork() {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public void forkWithSuccessMessage(FormMessage message) {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public void forkWithErrorMessage(FormMessage message) {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public EventBuilder getEvent() {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public EventBuilder newEvent() {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public AuthenticationExecutionModel getExecution() {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public AuthenticationFlowModel getTopLevelFlow() {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public RealmModel getRealm() {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public UriInfo getUriInfo() {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public KeycloakSession getSession() {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public BruteForceProtector getProtector() {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public FormMessage getForwardedErrorMessage() {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public FormMessage getForwardedSuccessMessage() {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public FormMessage getForwardedInfoMessage() {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public void setForwardedInfoMessage(String message, Object... parameters) {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public String generateAccessCode() {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public AuthenticationExecutionModel.Requirement getCategoryRequirementFromCurrentFlow(String authenticatorCategory) {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public void success() {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public void failure(AuthenticationFlowError error) {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public void failure(AuthenticationFlowError error, Response response) {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public void failure(AuthenticationFlowError error, Response response, String eventDetails, String userErrorMessage) {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public void challenge(Response challenge) {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public void forceChallenge(Response challenge) {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public void failureChallenge(AuthenticationFlowError error, Response challenge) {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public void attempted() {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public FlowStatus getStatus() {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public AuthenticationFlowError getError() {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public String getEventDetails() {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public String getUserErrorMessage() {
+            throw new IllegalStateException();
+        }
+    }

--- a/src/test/java/org/keycloak/authentication/authenticators/conditional/util/TestClientConnection.java
+++ b/src/test/java/org/keycloak/authentication/authenticators/conditional/util/TestClientConnection.java
@@ -1,0 +1,38 @@
+package org.keycloak.authentication.authenticators.conditional.util;
+
+import org.keycloak.common.ClientConnection;
+
+class TestClientConnection implements ClientConnection {
+
+    private final String remoteAddr;
+
+    TestClientConnection(String remoteAddr) {
+        this.remoteAddr = remoteAddr;
+    }
+
+    @Override
+    public String getRemoteAddr() {
+        return remoteAddr;
+    }
+
+    @Override
+    public String getRemoteHost() {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public int getRemotePort() {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public String getLocalAddr() {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public int getLocalPort() {
+        throw new IllegalStateException();
+    }
+}
+

--- a/src/test/java/org/keycloak/authentication/authenticators/conditional/util/TestHttpHeaders.java
+++ b/src/test/java/org/keycloak/authentication/authenticators/conditional/util/TestHttpHeaders.java
@@ -1,0 +1,70 @@
+package org.keycloak.authentication.authenticators.conditional.util;
+
+import jakarta.ws.rs.core.Cookie;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+class TestHttpHeaders implements HttpHeaders {
+
+    private final Map<String, List<String>> headers;
+
+    TestHttpHeaders(Map<String, List<String>> headers) {
+        this.headers = headers;
+    }
+
+    @Override
+    public List<String> getRequestHeader(String name) {
+        return headers.get(name);
+    }
+
+    @Override
+    public String getHeaderString(String name) {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public MultivaluedMap<String, String> getRequestHeaders() {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public List<MediaType> getAcceptableMediaTypes() {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public List<Locale> getAcceptableLanguages() {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public MediaType getMediaType() {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public Locale getLanguage() {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public Map<String, Cookie> getCookies() {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public Date getDate() {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public int getLength() {
+        throw new IllegalStateException();
+    }
+}

--- a/src/test/java/org/keycloak/authentication/authenticators/conditional/util/TestHttpRequest.java
+++ b/src/test/java/org/keycloak/authentication/authenticators/conditional/util/TestHttpRequest.java
@@ -1,0 +1,50 @@
+package org.keycloak.authentication.authenticators.conditional.util;
+
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.UriInfo;
+import org.keycloak.http.FormPartValue;
+import org.keycloak.http.HttpRequest;
+
+import java.security.cert.X509Certificate;
+import java.util.List;
+import java.util.Map;
+
+class TestHttpRequest implements HttpRequest {
+
+        private final HttpHeaders httpHeaders;
+
+        TestHttpRequest(Map<String, List<String>> headers) {
+            this.httpHeaders = new TestHttpHeaders(headers);
+        }
+
+        @Override
+        public HttpHeaders getHttpHeaders() {
+            return httpHeaders;
+        }
+
+        @Override
+        public String getHttpMethod() {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public MultivaluedMap<String, String> getDecodedFormParameters() {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public MultivaluedMap<String, FormPartValue> getMultiPartFormParameters() {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public X509Certificate[] getClientCertificateChain() {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public UriInfo getUri() {
+            throw new IllegalStateException();
+        }
+    }


### PR DESCRIPTION
* Respect all ip addresses if a header contains multiple addresses
* Respect all headers if it is present multiple times
* Add a toggle to enable using a header or always use the IP address from the client connection (Otherwise, a bad actor can just send a spoofed X-Forwarded-For header)
* Add an optional parameter to specify a custom header name
* Add an option to specify the number of trusted reverse proxies (If you are running 2 reverse proxies, only the last 2 IP addresses can be trusted, with the second last address being the client)

For information on why this is necessary, the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For) explain it pretty well (especially the section "[Security and privacy concerns](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For#security_and_privacy_concerns)")

Example:
![image](https://github.com/user-attachments/assets/4aef5d00-54cf-441d-a196-a26043aea8b6)

Resolves #6