### PR TITLE
Bump Keycloak to 26.6.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <name>Keycloak IP-Address Authenticator</name>
 
     <properties>
-        <keycloak.version>26.4.0</keycloak.version>
+        <keycloak.version>26.6.3</keycloak.version>
         <seancfoley.ipaddress.version>5.5.0</seancfoley.ipaddress.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
## What

Bumps the `keycloak.version` property from `26.4.0` to `26.6.3` so the extension builds against the current Keycloak release line. The artifact version follows automatically (`26.6.3_0`).

## Why

The latest published release (`26.4.0_0`) targets Keycloak 26.4. Keycloak has since shipped 26.5 / 26.6, and deployments on 26.6.x need an extension JAR built against that line — an extension compiled against an older Keycloak can throw `NoSuchMethodError` / `NoClassDefFoundError` at runtime when internal Keycloak APIs change between minor releases.

## Changes

- `pom.xml`: `<keycloak.version>26.4.0</keycloak.version>` → `<keycloak.version>26.6.3</keycloak.version>` — one line, no source changes.

## Verification

Built with `maven:3.9.16` against Keycloak 26.6.3:

- `mvn clean package` → `BUILD SUCCESS`
- All 7 unit tests pass (`ConditionalClientIpAddressAuthenticatorTest`)
- Produces `keycloak-ipaddress-authenticator-26.6.3_0-jar-with-dependencies.jar`

No source changes were required — the extension compiles cleanly and the existing tests pass unchanged against 26.6.3.
